### PR TITLE
Automatically install project on docker compose up

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,7 +52,7 @@ services:
         - GID=${GID:-1000}
     user: "${UID:-1000}:${GID:-1000}"
     working_dir: /var/www/html
-    entrypoint: ['composer']
+    entrypoint: ['composer', 'install']
     volumes:
       - ./docker/php/php.ini:/usr/local/etc/php/conf.d/local.ini
       - .:/var/www/html


### PR DESCRIPTION
Without it, Composer just outputs help on startup:

<img width="1121" alt="image" src="https://github.com/user-attachments/assets/e471b90b-1320-445b-8665-364c1d1fb4da">
